### PR TITLE
Fix stat function calls

### DIFF
--- a/variables/variables.py
+++ b/variables/variables.py
@@ -5,7 +5,6 @@ import inspect
 
 # So functions in these work..
 import os
-import stat
 
 def my_extension(  s : str ):
     parts = os.path.splitext(s)
@@ -15,10 +14,10 @@ def no_extension(  s : str ):
     return parts[0]
 
 def stat_st_mtime( s : str ):
-    s = stat(s)
+    s = os.stat(s)
     return s.st_mtime
 def stat_st_size( s : str ):
-    s = stat(s)
+    s = os.stat(s)
     return s.st_size
 
 


### PR DESCRIPTION
During testing of the tool, found that `stat.st_mtime` and `.st_size` failed with the following traceback:
```
PS C:\Users\omontoya> & C:/Python310/python.exe c:/Users/omontoya/simple_vars/test.py
Traceback (most recent call last):
  File "c:\Users\omontoya\simple_vars\test.py", line 8, in <module>
    result = my_vars.resolve( s )
  File "c:\Users\omontoya\simple_vars\variables\variables.py", line 306, in resolve
    (progress,text) = tmp.do_pass( text )
  File "c:\Users\omontoya\simple_vars\variables\variables.py", line 260, in do_pass
    return self._do_function_call( lhs, func_match, rhs )
  File "c:\Users\omontoya\simple_vars\variables\variables.py", line 205, in _do_function_call
    result = func_ptr( *param_list )
  File "c:\Users\omontoya\simple_vars\variables\variables.py", line 18, in stat_st_mtime
    s = stat(s)
TypeError: 'module' object is not callable
```
The cause of the error was the use of the `stat` module for getting the status of a file. 

Changed function call to use `os.stat()`, which gets a file's status. 

Removed module import, as it is not used elsewhere in the project.