### PR TITLE
Fix Var_UndefinedFunc initialization

### DIFF
--- a/variables/variables.py
+++ b/variables/variables.py
@@ -96,7 +96,7 @@ class Var_UndefinedFunc( VarError ):
     '''
     Raised when an undefined variable function is called.
     '''
-    def __init( self,   name : str, history : list ):
+    def __init__( self,   name : str, history : list ):
         VarError.__init__( self, VarError.UNDEF_FUNC, "undefined function: %s" % name, history )
         self.name = name
 


### PR DESCRIPTION
The exception that is raised in `_do_function_call()` was reverting to the base `VarError` instead of the `Var_UndefinedFunc`. The base class required three arguments and only two were provided.

This was because the `__init__` was missing the final underscores. Corrected definition of `__init__`.